### PR TITLE
Add Composer installers support and set sane defaults for installer-paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require": {
         "php": ">=5.5.9",
         "composer-plugin-api": "^1.1",
+        "composer/installers": "^1.2",
         "drupal-composer/drupal-scaffold": "^2.2",
         "symfony/filesystem": "^3.3",
         "webflo/drupal-finder": "^1.0",

--- a/src/ComposerInstallersHelper.php
+++ b/src/ComposerInstallersHelper.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Hussainweb\DrupalComposerHelper;
+
+use Composer\Composer;
+
+class ComposerInstallersHelper
+{
+
+    private $composer;
+
+    private $options;
+
+    /**
+     * The installer paths optimal for a composer based Drupal setup.
+     *
+     * @var array
+     */
+    private $installerPaths = [
+        'core' => '{$prefix}core/',
+        'module' => '{$prefix}modules/contrib/{$name}/',
+        'theme' => '{$prefix}themes/contrib/{$name}/',
+        'library' => '{$prefix}libraries/{$name}/',
+        'profile' => '{$prefix}profiles/contrib/{$name}/',
+        'drush' => 'drush/{$name}/',
+        'custom-theme' => '{$prefix}themes/custom/{$name}/',
+        'custom-module' => '{$prefix}modules/custom/{$name}/',
+    ];
+
+    public function __construct(Composer $composer, Options $options)
+    {
+        $this->composer = $composer;
+        $this->options = $options;
+    }
+
+    public function setInstallerPaths()
+    {
+        $extra = $this->composer->getPackage()->getExtra() + ['installer-paths' => []];
+
+        // Get the configured prefix.
+        $prefix = $this->options->get('web-prefix');
+
+        // Get the existing Drupal specific installer paths.
+        $installer_paths = $this->getDrupalInstallerPaths();
+
+        // Set the installer paths we need for Drupal.
+        foreach ($this->installerPaths as $type => $path) {
+            $type_key = 'type:drupal-' . $type;
+            if (empty($installer_paths[$type_key])) {
+                $path = str_replace('{$prefix}', $prefix . '/', $path);
+                $extra['installer-paths'][$path] = [$type_key];
+            }
+        }
+        $this->composer->getPackage()->setExtra($extra);
+    }
+
+    private function getDrupalInstallerPaths()
+    {
+        $extra = $this->composer->getPackage()->getExtra();
+        if (!isset($extra['installer-paths'])) {
+            return false;
+        }
+
+        $output = [];
+        foreach ($extra['installer-paths'] as $path => $filters) {
+            foreach ($filters as $filter) {
+                if (substr($filter, 0, 12) == 'type:drupal-') {
+                    $output[$filter] = $path;
+                }
+            }
+        }
+
+        return $output;
+    }
+}

--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -30,7 +30,9 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
     /**
      * @var DrupalVendorCleanup
      */
-    protected $drupalVendorCleanup;
+    private $drupalVendorCleanup;
+
+    private $options;
 
     /**
      * {@inheritdoc}
@@ -39,9 +41,14 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
     {
         $this->composer = $composer;
         $this->io = $io;
+        $this->options = new Options($composer);
 
         $vendor_dir = $composer->getConfig()->get('vendor-dir');
         $this->drupalVendorCleanup = new DrupalVendorCleanup($vendor_dir, $io);
+
+        // Set sane defaults for Drupal installer paths.
+        $composer_installers_helper = new ComposerInstallersHelper($composer, $this->options);
+        $composer_installers_helper->setInstallerPaths();
     }
 
     /**

--- a/src/Options.php
+++ b/src/Options.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Hussainweb\DrupalComposerHelper;
+
+use Composer\Composer;
+
+class Options
+{
+
+    private $composer;
+
+    public function __construct(Composer $composer)
+    {
+        $this->composer = $composer;
+    }
+
+    public function get($key = '')
+    {
+        $extra = $this->composer->getPackage()->getExtra() + [
+                'drupal-composer-helper' => [
+                    'web-prefix' => 'web',
+                ],
+            ];
+
+        return $key ? $extra['drupal-composer-helper'][$key] : $extra['drupal-composer-helper'];
+    }
+}


### PR DESCRIPTION
With this change, there won't be an explicit need to set installer-paths for Drupal specific paths anymore. They will be respected if they are there.