### PR TITLE
Fixes #15: Remove the visbility modifier for const.

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -6,7 +6,7 @@ use Composer\Composer;
 
 class Options
 {
-    public const DEFAULT_WEB_PREFIX = 'web';
+    const DEFAULT_WEB_PREFIX = 'web';
 
     private $composer;
 


### PR DESCRIPTION
This is not supported on older versions of PHP and public is the default anyway.